### PR TITLE
fixing .env variable

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -5,7 +5,7 @@ dotenv.config({  path: './.env' });
 
 const connectDB = async() => {
  //Add db connect string in .env file with variable name MONGODB_CONNECT
-    mongoose.connect("process.env.MONGODB_CONNECT")
+    mongoose.connect(process.env.MONGODB_CONNECT)
     .then(() => {
         console.log("Connected to DB")
     })


### PR DESCRIPTION
Mistakenly put .env var as a string. Fixed.